### PR TITLE
moving request dev dependency to normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "git://github.com/RIAEvangelist/node-dominos-pizza-api.git"
   },
   "dependencies": {
-    "xml2json": "^0.5.1"
+    "xml2json": "^0.5.1",
+    "request": "^2.50.0"
   },
   "keywords": [
     "Dominos",


### PR DESCRIPTION
after npm install dominos you receive this error if you do not have 'request'. 

version matches the dev dependency, and should be straight forward.

> dominos = require('dominos');
Error: Cannot find module 'request'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/hiroshi/git/randominos/node_modules/dominos/dominos-pizza-api.js:1:77)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)