### PR TITLE
allow multi line addresses in store finder

### DIFF
--- a/dominos-pizza-api.js
+++ b/dominos-pizza-api.js
@@ -4,7 +4,7 @@ var api={};
 api.track="https://trkweb.dominos.com/orderstorage/GetTrackerData?"
 
 api.store={};
-api.store.find='https://order.dominos.com/power/store-locator?s=${address}&type=${type}';
+api.store.find='https://order.dominos.com/power/store-locator?s=${line1}&c=${line2}&type=${type}';
 api.store.info='https://order.dominos.com/power/store/${storeID}/profile';
 api.store.menu='https://order.dominos.com/power/store/${storeID}/menu?lang=${lang}&structured=true';
 
@@ -73,10 +73,16 @@ function findStores(address, callback, type) {
     if(!type)
         type='all';
     
+    if(typeof address== "string")
+        address = [address, ' '];
+
     requestJSONAPI(
         api.store.find.replace(
-            '${address}',
-            encodeURI(address)
+            '${line1}',
+            encodeURI(address[0])
+        ).replace(
+            '${line2}',
+            encodeURI(address[1])
         ).replace(
             '${type}',
             type

--- a/example/api-examples/dominos-store-data.js
+++ b/example/api-examples/dominos-store-data.js
@@ -16,6 +16,15 @@ dominos.store.find(
     }
 );
 
+//Get stores near an exact multi-line address, they will be sorted by distance
+dominos.store.find(
+    ['1600 Pennsylvania Ave NW', 'Washington, DC 20500'], //address to search for nearby stores
+    function(storeData){ //callback to run when api returns
+        console.log('\n\n########################\nDomino\'s Near Multi-Line Address Sorted by distance\n########################\n', storeData,  '\n-------------------------\n', storeData.result.Stores,'\n############\n');
+    }
+);
+
+
 //Get Store Info for Store #4336
 dominos.store.info(
     4336, //storeID


### PR DESCRIPTION
This is necessary for addresses such as college dorms (which dominos allows on their site).