### PR TITLE
First pass on menu parsing

### DIFF
--- a/dominos-pizza-api.js
+++ b/dominos-pizza-api.js
@@ -7,4 +7,8 @@ module.exports = {
     Item: require('./src/Item'),
     Coupon: require('./src/Coupon'),
     Util: require('./src/Utilities'),
+    
+    Menu: require('./src/Menu'),
+    MenuItem: require('./src/MenuItem'),
+    MenuCategory: require('./src/MenuCategory'),
 };

--- a/example/api-examples/dominos-store-menu.js
+++ b/example/api-examples/dominos-store-menu.js
@@ -12,10 +12,27 @@ pizzapi.Util.findNearbyStores(
         );
 
         //Get Menu for first store
-        Store.getMenu(
-            function(storeData) {
-                console.log('\n\n##################\nFirst Store Menu\n##################\n\n',storeData.result);
+        Store.getMenu(function(raw,menu) {
+            function printCategory(showItems,category,depth) {
+                if (!depth) depth = 0;
+                var indent = Array(depth+1).join("  ");
+                console.log(indent+category.getName());
+                for (var subIndex in category.getSubcategories()) {
+                    printCategory(showItems,category.getSubcategories()[subIndex],depth+1);
+                }
+                if (showItems) {
+                    category.getProducts().forEach(function(product) {
+                        console.log(indent+"  ["+product.getCode()+"] "+product.getName());
+                    });
+                }
             }
-        );
+
+            console.log("************ Coupon Menu ************");
+            printCategory(true,menu.getCouponCategory(),1);
+            console.log("\n\n************ Preconfigured Menu ************");
+            printCategory(true,menu.getPreconfiguredCategory(),1);
+            console.log("\n\n************ Regular Menu ************");
+            printCategory(true,menu.getFoodCategory(),1);
+        });
     }
 );

--- a/example/api-examples/dominos-store-menu.js
+++ b/example/api-examples/dominos-store-menu.js
@@ -12,7 +12,7 @@ pizzapi.Util.findNearbyStores(
         );
 
         //Get Menu for first store
-        Store.getMenu(function(raw,menu) {
+        Store.getMenu(function(menu) {
             function printCategory(showItems,category,depth) {
                 if (!depth) depth = 0;
                 var indent = Array(depth+1).join("  ");

--- a/example/commandline-pizza/dominos-commandline-pizza.js
+++ b/example/commandline-pizza/dominos-commandline-pizza.js
@@ -122,7 +122,8 @@ function showMenu(storeID,quick){
     );
 
     store.getMenu(
-        function(data){
+        function(menu){
+            var data = menu.getRaw();
             if(quick){
                 console.log(
                     '\n##########################\n'.blue,

--- a/src/Item.js
+++ b/src/Item.js
@@ -11,7 +11,7 @@ var Item = function(parameters) {
     this.Code = parameters.code||null;
     this.Qty = parameters.quantity||1;
     this.ID = 1;
-
+    
     this.isNew = true;
     this.Options = { 'C': {'1/1': '1'}, 'X': {'1/1': '1'} };
 

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -1,0 +1,76 @@
+'use strict';
+
+var MenuItem = require('./MenuItem');
+var MenuCategory = require('./MenuCategory');
+
+var Menu = function(menuData) {
+    if(!menuData) {
+        menuData={};
+    } else {
+        this.parseMenu(menuData);
+    }
+    this.menuData = menuData;
+}
+
+Menu.prototype.getRaw = function() {
+    return this.menuData;
+}
+
+Menu.prototype.buildCategories = function(categoryData,parent) {
+    var category = new MenuCategory(categoryData,parent);
+    for (var subIndex in categoryData.Categories) {
+        category.getSubcategories().push(this.buildCategories(categoryData.Categories[subIndex],category));
+    }
+    categoryData.Products.forEach((function(productCode) { //link up products and categories
+        var product = this.menuByCode[productCode];
+        if (!product) {
+            console.log("PRODUCT NOT FOUND: "+productCode,category.getCode());
+            return;
+        }
+        category.getProducts().push(product);
+        product.getCategories().push(category);
+    }).bind(this));
+    return category;
+}
+
+Menu.prototype.parseItems = function(parentMenuData,ParseClass) {
+    var items = [];
+    Object.keys(parentMenuData).forEach((function(code) {
+        var menuData = parentMenuData[code];
+        var obj = new ParseClass(menuData);
+        this.menuByCode[obj.getCode()] = obj;
+        items.push(obj);
+    }).bind(this));
+    return items;
+}
+
+Menu.prototype.parseMenu = function(menuData) {    
+    this.menuByCode = {};
+    var products = this.parseItems(menuData.result.Products,MenuItem);
+    var coupons = this.parseItems(menuData.result.Coupons,MenuItem);
+    var preconfigured = this.parseItems(menuData.result.PreconfiguredProducts,MenuItem);
+
+    this.rootCategories = {}; //generate category tree using MenuCategory objects
+    for (var categoryType in menuData.result.Categorization) {
+        var categoryData = menuData.result.Categorization[categoryType];
+        this.rootCategories[categoryType] = this.buildCategories(categoryData);
+    }
+}
+
+Menu.prototype.getFoodCategory = function() {
+    return this.rootCategories["Food"];
+}
+
+Menu.prototype.getCouponCategory = function() {
+    return this.rootCategories["Coupons"];
+}
+
+Menu.prototype.getPreconfiguredCategory = function() {
+    return this.rootCategories["PreconfiguredProducts"];
+}
+
+Menu.prototype.getItemByCode = function(code) {
+    return this.menuByCode(code);
+}
+
+module.exports = Menu;

--- a/src/MenuCategory.js
+++ b/src/MenuCategory.js
@@ -1,0 +1,38 @@
+'use strict';
+
+
+var MenuCategory = function(menuData,parentCategory) {
+    if(!menuData) menuData={};
+
+    this.menuData = menuData;
+    this.subcategories = [];
+    this.products = [];
+    this.parent = parentCategory;
+}
+
+MenuCategory.prototype.getSubcategories = function() {
+    return this.subcategories;
+}
+
+MenuCategory.prototype.getName = function() {
+    return this.menuData.Name;
+}
+
+MenuCategory.prototype.getDescription = function() {
+    return this.menuData.Description;
+}
+
+MenuCategory.prototype.getCode = function() {
+    return this.menuData.Code;
+}
+
+MenuCategory.prototype.getCategoryPath = function() {
+    var result = this.parent !== undefined ? this.parent.getCategoryPath().concat([this.menuData.Code]) : [this.menuData.Code];
+    return result;
+}
+
+MenuCategory.prototype.getProducts = function() {
+    return this.products;
+}
+
+module.exports = MenuCategory;

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -1,0 +1,31 @@
+'use strict';
+
+
+var MenuItem = function(menuData) {
+    if(!menuData) menuData={};
+
+    this.menuData = menuData;
+    this.categories = [];
+}
+
+MenuItem.prototype.setCategories = function(categories) {
+    return this.categories = categories;
+}
+
+MenuItem.prototype.getCategories = function() {
+    return this.categories;
+}
+
+MenuItem.prototype.getName = function() {
+    return this.menuData.Name;
+}
+
+MenuItem.prototype.getDescription = function() {
+    return this.menuData.Description;
+}
+
+MenuItem.prototype.getCode = function() {
+    return this.menuData.Code;
+}
+
+module.exports = MenuItem;

--- a/src/Order.js
+++ b/src/Order.js
@@ -49,6 +49,7 @@ var Order = function(parameters) {
     this.Email = Customer.email;
     this.FirstName = Customer.firstName;
     this.LastName = Customer.lastName;
+    this.Phone = Customer.phone;
     return this;
   }
   if(parameters['Order'] || parameters['order']) {  //Used to initialize order object from Dominos results (Also handy for initializing from DB)

--- a/src/Order.js
+++ b/src/Order.js
@@ -173,7 +173,7 @@ Order.prototype.mergeResponse = function(callback,response){
         }
         this[key]=response.result.Order[key];
     }
-    console.log(util.inspect(this.Products, { showHidden: true, depth: 5 }));
+    //console.log(util.inspect(this.Products, { showHidden: true, depth: 5 }));
     if(callback){
         callback(response);
     }

--- a/src/Store.js
+++ b/src/Store.js
@@ -27,7 +27,7 @@ Store.prototype.getInfo = function(callback) {
 
 Store.prototype.getMenu = function(callback, lang, noCache) {
     if (this.cachedMenu && !noCache) {
-        callback(this.cachedMenu.getRaw(),this.cachedMenu); //TODO as below, break compatibility by removing first parameter
+        callback(this.cachedMenu); //TODO as below, break compatibility by removing first parameter
         return;
     }
     if( !this.ID || !callback){
@@ -48,7 +48,7 @@ Store.prototype.getMenu = function(callback, lang, noCache) {
 
     httpJson.get(url,(function(jsonObj) {
         this.cachedMenu = new Menu(jsonObj);
-        callback(jsonObj,this.cachedMenu); //TODO break compatibility by removing first parameter
+        callback(this.cachedMenu); //TODO break compatibility by removing first parameter
     }).bind(this));
 
     /*

--- a/test/menu_test.js
+++ b/test/menu_test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var mocha = require('mocha');
+var chai = require('chai');
+var expect = chai.expect;
+var Store = require('../src/Store');
+
+var testStore = 8386;
+
+//TODO this test needs fleshing out
+describe('Menu', function() {
+  this.timeout(15000);
+  describe('ParseMenu', function() {
+    it('should parse menu', function(done) {
+        var store = new Store({ID: testStore});
+        store.getMenu(function(raw,menu) {
+            expect(raw).not.to.be.null;
+            expect(menu).not.to.be.null;
+            
+            
+            expect(menu.getFoodCategory()).not.to.be.null;
+            expect(menu.getCouponCategory()).not.to.be.null;
+            expect(menu.getPreconfiguredCategory()).not.to.be.null;
+
+            var pizzaItem = menu.getItemByCode("S_PIZZA");
+            expect(pizzaItem).not.to.be.null;
+            
+            expect(pizzaItem.getName().to.be.equal("Pizza"));
+            
+            done();
+        });
+        
+        done();
+    });
+  });
+});

--- a/test/menu_test.js
+++ b/test/menu_test.js
@@ -13,10 +13,8 @@ describe('Menu', function() {
   describe('ParseMenu', function() {
     it('should parse menu', function(done) {
         var store = new Store({ID: testStore});
-        store.getMenu(function(raw,menu) {
-            expect(raw).not.to.be.null;
+        store.getMenu(function(menu) {
             expect(menu).not.to.be.null;
-            
             
             expect(menu.getFoodCategory()).not.to.be.null;
             expect(menu.getCouponCategory()).not.to.be.null;

--- a/test/store_test.js
+++ b/test/store_test.js
@@ -34,8 +34,8 @@ describe('Store', function() {
 
     newStore.getMenu(function(menu) {
       expect(menu).to.exist;
-      expect(menu.result).to.exist;
-      expect(menu.result.Misc.StoreID).to.equal('1546');
+      expect(menu.getRaw().result).to.exist;
+      expect(menu.getRaw().result.Misc.StoreID).to.equal('1546');
 
       done();
     });


### PR DESCRIPTION
I've created a few new classes: Menu, MenuItem, and MenuCategory

Store.getMenu now populates the callback's second parameter with a parsed menu as a Menu object. (Note: At some point we should break compatibility and make this return only a Menu object. Users who need the raw object can use Menu.getRaw())

The Menu parsing is currently being showcased in dominos-store-menu.js. I've edited this example to print out the menu in a hierarchical fashion.

I've added a basic smoke test for the menu parsing under menu_test.js

I'll be adding more functionality to this soon, but this seems stable and functional so far.

In this pull request, I've also commented out a line of debugging information in Order.mergeResponse.