### PR TITLE
Update Store parameters.ID ~> ID

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -6,8 +6,8 @@ var util=require('util');
 var fs=require('fs');
 var Menu=require('./Menu.js');
 
-var Store = function(parameters) {
-    this.ID = parameters.ID;
+var Store = function(ID) {
+    this.ID = ID;
 };
 
 Store.prototype.getInfo = function(callback) {


### PR DESCRIPTION
Bug Fix `"parameters"  has no variable called "ID"`


`Store` takes only one parameter `ID`, No need for `parameters`in plural