### PR TITLE
Update tracking URL

### DIFF
--- a/src/urls.json
+++ b/src/urls.json
@@ -11,5 +11,5 @@
     "price": "https://order.dominos.com/power/price-order",
     "place": "https://order.dominos.com/power/place-order"
   },
-  "track": "https://trkweb.dominos.com/orderstorage/GetTrackerData?"
+  "track": "https://order.dominos.com/orderstorage/GetTrackerData?"
 }


### PR DESCRIPTION
Hi! trkweb.dominos.com is no longer a valid hostname.

I just tested this and the new tracking endpoint is under order.dominos.com; same parameters as before.