### PR TITLE
v3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ try{
 
 The module now supports using multiple sets of endpoints that we have in `./utils/urls.js` or even custom endpoints. However, if you get hyour country working with custom endpoints, ***PLEASE CONTRIBUTE THEM BACK***! You will get credit as soon as your endpoints are merged back in.
 
-See detailed information on how to use the international endpoints or custom endpoints here : [International Dominos Endpoints and how to use them](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/InternationalSupport.md)
+See detailed information on how to use the international endpoints or custom endpoints here : [International Dominos Endpoints and how to use them](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/InternationalSupport.md)
 
 ### USA
 USA is default so you really dont need to do anything other than `import {urls} from 'dominos';` if you want access to the usa endpoints.
@@ -280,7 +280,7 @@ USA is default so you really dont need to do anything other than `import {urls} 
 
 # Address
 
-See the detailed docs on addresses here : [Address.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Address.md)
+See the detailed docs on addresses here : [Address.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Address.md)
 
 ```js
 
@@ -340,7 +340,7 @@ See the detailed docs on addresses here : [Address.md](https://github.com/RIAEva
 
 This provides a list of basic info on stores that are nearby an address.
 
-See the detailed docs on finding nearby stores here : [NearbyStores.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/NearbyStores.md)
+See the detailed docs on finding nearby stores here : [NearbyStores.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/NearbyStores.md)
 
 ``` js
 
@@ -367,7 +367,7 @@ See the detailed docs on finding nearby stores here : [NearbyStores.md](https://
 
 This provides a detailed menu for a given store.
 
-See the detailed docs on menus here : [Menu.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Menu.md)
+See the detailed docs on menus here : [Menu.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Menu.md)
 
 ```js
 
@@ -385,7 +385,7 @@ console.dir(menu,{depth:1});
 
 This provides detailed store information.
 
-See the detailed docs on stores here : [Store.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Store.md)
+See the detailed docs on stores here : [Store.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Store.md)
 
 ```js
 
@@ -403,7 +403,7 @@ See the detailed docs on stores here : [Store.md](https://github.com/RIAEvangeli
 
 Items are used to place orders.
 
-See the detailed docs on items here : [Item.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Item.md)
+See the detailed docs on items here : [Item.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Item.md)
 
 ```js
 import {Item} from 'dominos';
@@ -424,7 +424,7 @@ console.dir(pepperoniPizza);
 
 This creates a customer object for use when making an order.
 
-See the detailed docs on customers here : [Customer.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Customer.md)
+See the detailed docs on customers here : [Customer.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Customer.md)
 
 ```js
 
@@ -451,7 +451,7 @@ The Image class will grab the image for a product code and base 64 encode it. It
 
 ![Pizza image](https://cache.dominos.com/olo/6_47_2/assets/build/market/US/_en/images/img/products/larges/S_PIZPX.jpg)
 
-See the detailed docs on image here : [Image.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Image.md)
+See the detailed docs on image here : [Image.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Image.md)
 
 ```js
 
@@ -477,7 +477,7 @@ pepperoniPizza.saveSync(pepperoniPizza.base64Image,savePath,productCode+'.jpg');
 
 This class will initialize a creditcard payment object for an order.
 
-See the detailed docs on payment here : [Payment.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Payment.md)
+See the detailed docs on payment here : [Payment.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Payment.md)
 
 
 ```js
@@ -504,7 +504,7 @@ const myCard=new Payment(
 
 ***Finally...*** This class will order you pizza, and other things from the menu.
 
-See the detailed docs on order here : [Order.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Order.md)
+See the detailed docs on order here : [Order.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Order.md)
 
 
 ```js
@@ -583,7 +583,7 @@ This is how you track Pizzas! (and other things)
 
 Rely on the `order.place` response. If the order fails, it will throw a `DominosPlaceOrderError`. Otherwise, your pizza is on the way. It also seems that orders placed via `dominos` module do not show up on the tracking website right now. These orders appear stealth at the moment.
 
-See the detailed docs on tracking here : [Tracking.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Tracking.md)
+See the detailed docs on tracking here : [Tracking.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Tracking.md)
 
 ```js
 
@@ -617,7 +617,7 @@ console.dir(trackingResult,{depth:1});
 
 This class extends [`strong-type`](https://github.com/RIAEvangelist/strong-type) to allow strong and weak type checking of dominos specific types, errors and classes. It is used a lot in the `dominos` module to ensure correct types of arguments and errors. The `strong-type` module is really cool. 
 
-See the [DominosTypes.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosTypes.md) for more information.
+See the [DominosTypes.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosTypes.md) for more information.
 
 ```js
 
@@ -650,7 +650,7 @@ isDominos.address(address);
 
 These custom errors are added to the global object for use in your code and the `dominos` api. You can use them to validate errors or even throw your own if you are making a module ontop of this one.
 
-See the detailed docs on DominosErrors here : [DominosErrors.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosErrors.md)
+See the detailed docs on DominosErrors here : [DominosErrors.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosErrors.md)
 
 |error                  |parameters           |description|
 |-----                  |----------           |-----------|

--- a/docs/Address.md
+++ b/docs/Address.md
@@ -5,7 +5,7 @@ This is the primary Address Class used for all things Domnio's.
 If you have cloned this repo, you can run the example with this command:
 `node ./example/address.js`
 
-extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md)
+extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md)
 
 Constructor
 ====
@@ -19,7 +19,7 @@ Constructor
 Instance
 ====
 
-Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md) as this class extends it.
+Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md) as this class extends it.
 
 |member/method|type  |description|
 |-------------|------|-------    |

--- a/docs/AmountsBreakdown.md
+++ b/docs/AmountsBreakdown.md
@@ -2,9 +2,9 @@ AmountsBreakdown
 ====
 This is the primary AmountsBreakdown Class used for all things Domnio's.
 
-Really unless you are working on the core of this module you don't need to understand this class as it is not used outside of the internals of the [Order Class](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Order.md) itself.
+Really unless you are working on the core of this module you don't need to understand this class as it is not used outside of the internals of the [Order Class](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Order.md) itself.
 
-extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md)
+extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md)
 
 Constructor
 ====
@@ -32,7 +32,7 @@ Constructor
 Instance
 ====
 
-Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md) as this class extends it.
+Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md) as this class extends it.
 
 |member/method|type  |description|
 |-------------|------|-------    |

--- a/docs/Customer.md
+++ b/docs/Customer.md
@@ -5,7 +5,7 @@ The customer class is used to create a customer instance for a Domino's Pizza Or
 If you have cloned this repo, you can run the example with this command:
 `node ./example/customer.js`
 
-extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md)
+extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md)
 
 Constructor
 ====
@@ -14,7 +14,7 @@ Constructor
 
 |params.argument|type  |required|description|
 |--------|------|--------|-------|
-|address      |[Address](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Address.md), AddressObject, AddressString|yes|customers Address. See more info on what is an acceptable Address/AddressObject or AddressString in the [Address.md doc](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Address.md)|
+|address      |[Address](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Address.md), AddressObject, AddressString|yes|customers Address. See more info on what is an acceptable Address/AddressObject or AddressString in the [Address.md doc](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Address.md)|
 |firstName  |String|yes||
 |lastName   |String|yes||
 |email      |String|yes||
@@ -23,11 +23,11 @@ Constructor
 Instance
 ====
 
-Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md) as this class extends it.
+Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md) as this class extends it.
 
 |member/method|type  |description|
 |-------------|------|-------    |
-|.address      |[Address](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Address.md)|customers Address|
+|.address      |[Address](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Address.md)|customers Address|
 |.firstName  |String| |
 |.lastName   |String||
 |.email      |String||

--- a/docs/DominosMenu.md
+++ b/docs/DominosMenu.md
@@ -2,14 +2,14 @@
 
 The `menu.domniosAPIResponse` object is ***HUGE***! It contains the actual dominos menu response with information on everything you could imagine for a Store's Menu. We parse this information and provide a simpler to use menu in `menu.menu`.
 
-If you want to see the easy to use parsed `.menu` object and documentation, check out the [parsed Dominos Pizza Menu.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Menu.md), it is designed to be much easier to use. 
+If you want to see the easy to use parsed `.menu` object and documentation, check out the [parsed Dominos Pizza Menu.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Menu.md), it is designed to be much easier to use. 
 
 
 ## menu.domniosAPIResponse
 
 |member                   |type  |description|
 |------                   |----  |-----------|
-|.Misc                    |Object|Contains general information about the API andmenu request to Dominos. Below you will find specific information for this request, and you can see some core information about the requests in the [Domino's API Response Doc](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosAPIResponse.md).|
+|.Misc                    |Object|Contains general information about the API andmenu request to Dominos. Below you will find specific information for this request, and you can see some core information about the requests in the [Domino's API Response Doc](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosAPIResponse.md).|
 |.Categorization          |Object|This contains categories of products. Each Category includes Sub categories and all the available products in that sub category for a specific store menu.|
 |.Coupons                 |Object||
 |.Flavors                 |Object||
@@ -53,7 +53,7 @@ If you want to see the easy to use parsed `.menu` object and documentation, chec
 
 # menu.domniosAPIResponse.Misc
 
-The `menu.domniosAPIResponse.Misc` object contains a little bit of useful information like the `StoreID` and date and time at the stores location. You can see some core information about the requests in the [Domino's API Response Doc](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosAPIResponse.md).
+The `menu.domniosAPIResponse.Misc` object contains a little bit of useful information like the `StoreID` and date and time at the stores location. You can see some core information about the requests in the [Domino's API Response Doc](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosAPIResponse.md).
 
 ```js
 

--- a/docs/Item.md
+++ b/docs/Item.md
@@ -5,7 +5,7 @@ Items are used to track what products, quantities, and options a customer would 
 If you have cloned this repo, you can run the example with this command:
 `node ./example/item.js`
 
-extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md)
+extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md)
 
 Constructor
 ====
@@ -23,7 +23,7 @@ Constructor
 Instance
 ====
 
-Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md) as this class extends it.
+Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md) as this class extends it.
 
 |member/method|type  |description|
 |-------------|------|-------    |

--- a/docs/Menu.md
+++ b/docs/Menu.md
@@ -3,7 +3,7 @@ Menu is constructed `async`, so when you instantiate it, you should await it, li
 
 `.menu` provides ***HUGE*** amounts of well formatted menu data parsed from the `menu.dominosAPIResponse` object. This information is parsed from the dominos api when the instance is instantiated.
 
-If you want to see the ***RAW*** `menu.dominosAPIResponse` object and documentation, check out the [RAW DominosMenu.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosMenu.md) instead. That object is huge and a little difficult to use which is why we provide this parsed menu.
+If you want to see the ***RAW*** `menu.dominosAPIResponse` object and documentation, check out the [RAW DominosMenu.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosMenu.md) instead. That object is huge and a little difficult to use which is why we provide this parsed menu.
 
 If you have cloned this repo, you can run the example with this command:
 `node ./example/menu.js`
@@ -35,7 +35,7 @@ Instance
 |member/method      |type               |description|
 |-------------      |------             |-------    |
 |.menu              |object             |parsed and more friendly menu for the store documented below.|
-|.dominosAPIResponse|API response object|see more info in the [RAW DominosMenu.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosMenu.md)|
+|.dominosAPIResponse|API response object|see more info in the [RAW DominosMenu.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosMenu.md)|
 
 
 # .menu

--- a/docs/NearbyStores.md
+++ b/docs/NearbyStores.md
@@ -13,7 +13,7 @@ Constructor
 
 |argument |type  |default   |description|
 |-------- |----  |-------   |--------|
-|address  |[Address](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Address.md) instance, or AddressObject or AddressString | |either an instance of the Address class or anthing that could be passed to the `Address` class to make an instance|
+|address  |[Address](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Address.md) instance, or AddressObject or AddressString | |either an instance of the Address class or anthing that could be passed to the `Address` class to make an instance|
 |type     |String|`Delivery`|`Delivery`, `Carryout`, `all`|
 
 
@@ -22,14 +22,14 @@ Instance
 
 |member/method      |type  |description|
 |-------------      |------|-------    |
-|address            |[Address](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Address.md)|An Address Instance populated with the Domino's Store information|
+|address            |[Address](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Address.md)|An Address Instance populated with the Domino's Store information|
 |stores             |Array| Array of basic store objects, see below.|
-|dominosAPIResponse |[Dominos API Response Object](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosAPIResponse.md)|Raw response from Domino's Each response is a little different, but you can see the core info in the [Domino's API Response Doc](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosAPIResponse.md). |
+|dominosAPIResponse |[Dominos API Response Object](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosAPIResponse.md)|Raw response from Domino's Each response is a little different, but you can see the core info in the [Domino's API Response Doc](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosAPIResponse.md). |
 
 ### By PostalCode
 ***this yields a wide variety of stores*** because it is not a very specific address. To find stores closer to you (or your user), use a more specific address.
 
-You can see the all the ways to pass an address [in the dominos pizza Address.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Address.md).
+You can see the all the ways to pass an address [in the dominos pizza Address.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Address.md).
 
 ```js
 

--- a/docs/Order.md
+++ b/docs/Order.md
@@ -5,7 +5,7 @@ This is the primary Order Class used for ordering Domnio's food!
 If you have cloned this repo, you can run the example with this command:
 `node ./example/order.js`
 
-extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md)
+extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md)
 
 
 ## Complete Order Example
@@ -156,22 +156,22 @@ Constructor
 
 |argument|type      |required|description|
 |--------|------    |--------|-------|
-|customer|[`Customer`](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Customer.md)|yes|This is a dominos customer instance|
+|customer|[`Customer`](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Customer.md)|yes|This is a dominos customer instance|
 
 
 Instance Hidden Methods & Hidden Fields
 ====
 
-Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md) as this class extends it.
+Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md) as this class extends it.
 
 
 |Hidden Method Name |Params |Description|
 |-----------------  |------ |-----------|
-|.addCustomer       |[Customer Instance](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Customer.md)|This will populate all `Customer` fields on the `Order` Instance|
+|.addCustomer       |[Customer Instance](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Customer.md)|This will populate all `Customer` fields on the `Order` Instance|
 |.addCoupon         |String |This will add a coupon string to the coupons array|
 |.removeCoupon      |String |This will find and remove a coupon string from the coupons array|
-|.addItem           |[Item Instance](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Item.md)|This will sanitize and add a product `Item` to the `.products` array|
-|.removeItem        |[Item Instance](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Item.md)|This will find and remove a product `Item` from the `.products` array|
+|.addItem           |[Item Instance](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Item.md)|This will sanitize and add a product `Item` to the `.products` array|
+|.removeItem        |[Item Instance](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Item.md)|This will find and remove a product `Item` from the `.products` array|
 |.orderInFuture     |Date   |Will set the order time to be in the future. Very useful when testing but stores are closed, or when you want to order things in the future.|
 |.orderNow          |       |This will ensure an order is made now and not in the future. If you had previously used `.orderInFuture`, its date will be removed.|
 |`async` .validate  |       |This will request dominos.com validate the current `Order` Instance.|
@@ -183,7 +183,7 @@ Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-
 |Hidden Field Name  |Type   |Description|
 |-----------------  |----   |-----------|
 |.payload           |JSON   |n/a   |
-|.formatted         |Object |this comes from [DominosFormat Class](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md) but the setter is overloaded for special Dominos Order format|
+|.formatted         |Object |this comes from [DominosFormat Class](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md) but the setter is overloaded for special Dominos Order format|
 |.validationResponse|Object|Validation Response Object from Dominos|
 |.priceResponse     |Object|Price Response Object from Dominos|
 |.placeResponse     |Object|Place Order Response Object from Dominos|
@@ -195,7 +195,7 @@ Instance Public Fields
 
 |member/method  |type  |default|description|
 |-------------  |------|-------|-----------|
-|.address       |[Address](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md)||Address for customer|
+|.address       |[Address](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md)||Address for customer|
 |.amounts       |Object||? Not sure, if you figure it out, please contribute to this doc. We are just using what the website uses here. It may be legacy and could be removed.|   
 |.amountsBreakdown|[AmountsBreakdown]()||populated by `order.price`, this is the break down of costs and taxes|
 |.businessDate  |String||This is the date the order was created at the business.| 
@@ -220,16 +220,16 @@ Instance Public Fields
 |.orderMethod   |String|'Web'|This is how the dominos.com site passes this information, there could be other options, but we do not know them. ?If you figure it out, please contribute to this doc.|            
 |.orderTaker    |String|'node-dominos-pizza-api'|? Perhaps the name of the person that took your order? Not sure, if you figure it out, please contribute to this doc.|            
 |.partners      |Object||? Not sure, if you figure it out, please contribute to this doc.|
-|.payments      |Array of [Payment Instances](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Payment.md)||This is how you pay for the order when you use the `.place` method.|
+|.payments      |Array of [Payment Instances](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Payment.md)||This is how you pay for the order when you use the `.place` method.|
 |.phone         |String||Customer's phonenumber, pupulated when instantiated by the passed Customer Object|
 |.priceOrderMs  |Number||?Perhaps how long it took to complete the pricing? Not sure, if you figure it out, please contribute to this doc.|
 |.priceOrderTime|String||The time when the order was priced by the `.price` method. This is provided by the dominos servers|
-|.products      |Array of [Item Instances](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Item.md)||Your product items are sanitized and added here by the `.addProduct` method|
+|.products      |Array of [Item Instances](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Item.md)||Your product items are sanitized and added here by the `.addProduct` method|
 |.promotions    |Array||? Not sure, perhaps some special promotions, if you figure it out, please contribute to this doc.|
 |.pulseOrderGuid|String||? populated by dominos.com and used by dominos|    
 |.serviceMethod |String|'Delivery'|How you plan to get your pizza, `'Delivery'`/`'Carryout'`/`'DriveUpCarryout'`|
 |.sourceOrganizationURI |String|'order.dominos.com'||    
-|.storeID       |String/Number||Id for the store you wish to order from. get this through the [NearbyStores class](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md)|
+|.storeID       |String/Number||Id for the store you wish to order from. get this through the [NearbyStores class](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md)|
 |.tags          |Object||? Not sure, if you figure it out, please contribute to this doc.|
 |.userAgent     |String||Auto populated when requests are made. We use `node-fetch`|
 |.version       |String|'1.0'|Dominos.com api version|        

--- a/docs/Payment.md
+++ b/docs/Payment.md
@@ -8,7 +8,7 @@ This class will initialize a creditcard payment object for an order
 If you have cloned this repo, you can run the example with this command:
 `node ./example/payment.js`
 
-extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md)
+extends `DominosFormat` class, see more in [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md)
 
 Constructor
 ====
@@ -27,7 +27,7 @@ Constructor
 Instance
 ====
 
-Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/DominosFormat.md) as this class extends it.
+Also check the [DominosFormat.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/DominosFormat.md) as this class extends it.
 
 |member/method  |type  |description|
 |-------------  |------|---      |-------    |

--- a/docs/Store.md
+++ b/docs/Store.md
@@ -30,7 +30,7 @@ Instance
 
 |member/method|type   |description|
 |-------------|------ |-------    |
-|.menu        |Menu   |parsed and more friendly menu for the store check out the [Dominos Pizza Menu.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/v3.x/docs/Menu.md) for more details.|
+|.menu        |Menu   |parsed and more friendly menu for the store check out the [Dominos Pizza Menu.md](https://github.com/RIAEvangelist/node-dominos-pizza-api/blob/master/docs/Menu.md) for more details.|
 |.info        |object |see the detailed store information object below.|
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dominos",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "node js API for Domino's pizza",
   "exports": "./index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dominos",
   "version": "3.0.0",
   "description": "node js API for Domino's pizza",
-  "exports": "index.js",
+  "exports": "./index.js",
   "type": "module",
   "scripts": {
     "test": "npm i && c8 -r lcov -r html node test/CI.js && c8 report",


### PR DESCRIPTION
Added `./` to `package.json` exports field so commonJS code can import the module via:

```js

const dominos=import('dominos');

``` 