### PR TITLE
Changing expected Coupon type from String to Object to apply correctly

### DIFF
--- a/modules/Order.js
+++ b/modules/Order.js
@@ -81,7 +81,7 @@ class Order extends DominosFormat{
     }
 
     addCoupon(couponCode) { 
-        isDominos.string(couponCode);
+        isDominos.object(couponCode);
         
         this.coupons.push(couponCode);
         
@@ -89,7 +89,7 @@ class Order extends DominosFormat{
     }
 
     removeCoupon(couponCode) { 
-        isDominos.string(couponCode);
+        isDominos.object(couponCode);
         
         return this.#remove(couponCode,this.coupons);;
     }

--- a/test/tests/order.js
+++ b/test/tests/order.js
@@ -86,7 +86,7 @@ const addAndRemoveCoupons=function(test){
         test.expects(`Order to add and then remove coupons.`);    
         
         const order=new Order(customer);
-        const coupon='FREE_PIZZA';
+        const coupon={'Code':'FREE_PIZZA'};
 
 
         order.addCoupon(coupon);


### PR DESCRIPTION
I found that applying the coupon codes directly as Strings did not apply the coupon to the order. While the coupon existed on the order after validation/pricing, it did not adjust the value of the order to account for the savings.

After trying a few things, I found that coupons can be applied following this style:
```
// OLD STYLE
coupons: ['FREE_PIZZA']; // Doesn't apply the coupon

// NEW STYLE
coupons: [{'Code' : 'FREE_PIZZA'}]; //This applies the coupon and shows the appropriate change(s) in the price response
```

Updated the appropriate unit test as well.